### PR TITLE
Create our own executor if none is provided.

### DIFF
--- a/src/main/java/sh/nerd/async/process/AsyncProcess.java
+++ b/src/main/java/sh/nerd/async/process/AsyncProcess.java
@@ -25,7 +25,9 @@ import static java.util.Spliterator.NONNULL;
 import static java.util.Spliterator.ORDERED;
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.concurrent.CompletableFuture.runAsync;
+import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.stream.StreamSupport.stream;
+import static sh.nerd.async.process.NamedThreadFactory.withPrefix;
 import static sh.nerd.async.process.SupplierIterator.supplyUntilNull;
 
 import java.io.BufferedReader;
@@ -54,6 +56,8 @@ public class AsyncProcess {
   private final Optional<Consumer<String>> outConsumer;
   private final Optional<Consumer<String>> errConsumer;
   private final Function<Runnable, CompletionStage<Void>> runner;
+  private final static String THREAD_PREFIX = "async-process";
+  private final static int NUM_THREADS = 3;
 
   /**
    * C'tor
@@ -74,8 +78,9 @@ public class AsyncProcess {
     inSupplier = Optional.ofNullable(in);
     outConsumer = Optional.ofNullable(out);
     errConsumer = Optional.ofNullable(err);
-    //TODO: create our own executor if not provided.
-    runner = isNull(exe) ? CompletableFuture::runAsync : runnable -> runAsync(runnable, exe);
+    runner = isNull(exe)
+             ? r -> runAsync(r, newFixedThreadPool(NUM_THREADS, withPrefix(THREAD_PREFIX)))
+             : r -> runAsync(r, exe);
 
   }
 

--- a/src/main/java/sh/nerd/async/process/AsyncProcess.java
+++ b/src/main/java/sh/nerd/async/process/AsyncProcess.java
@@ -78,10 +78,10 @@ public class AsyncProcess {
     inSupplier = Optional.ofNullable(in);
     outConsumer = Optional.ofNullable(out);
     errConsumer = Optional.ofNullable(err);
-    runner = isNull(exe)
-             ? r -> runAsync(r, newFixedThreadPool(NUM_THREADS, withPrefix(THREAD_PREFIX)))
-             : r -> runAsync(r, exe);
-
+    final Executor executor = isNull(exe)
+                              ? newFixedThreadPool(NUM_THREADS, withPrefix(THREAD_PREFIX))
+                              : exe;
+    runner = runnable -> runAsync(runnable, executor);
   }
 
   /**

--- a/src/main/java/sh/nerd/async/process/NamedThreadFactory.java
+++ b/src/main/java/sh/nerd/async/process/NamedThreadFactory.java
@@ -1,0 +1,60 @@
+/*
+ * -\-\-
+ * Async Process
+ * --
+ * Copyright (C) 2017 Olle Lundberg
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package sh.nerd.async.process;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A thread factory that creates threads with a prefix.
+ */
+public class NamedThreadFactory implements ThreadFactory {
+
+  private final AtomicInteger count = new AtomicInteger(0);
+  private final ThreadFactory defaultThreadFactory;
+  private final String prefix;
+
+  /**
+   * Creates a {@link ThreadFactory} that spawns threads named after the parameter prefix
+   *
+   * @param prefix prefix to use
+   */
+  public static NamedThreadFactory withPrefix(final String prefix) {
+    return new NamedThreadFactory(requireNonNull(prefix));
+  }
+
+  NamedThreadFactory(final String threadPrefix) {
+    prefix = threadPrefix + "-";
+    defaultThreadFactory = Executors.defaultThreadFactory();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Thread newThread(final Runnable runnable) {
+    final Thread thread = defaultThreadFactory.newThread(runnable);
+    thread.setName(prefix + count.getAndIncrement());
+    return thread;
+  }
+}


### PR DESCRIPTION
We don't want to run on the common pool as that might block
application threads.